### PR TITLE
Stop using "brainfuck" in our coding challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please select 1 of the below Ruby or SQL challenges, and 1 of the React challeng
 
 ### Frontend Roles
 
-Select either one of the React challenges ([_Messaging Client (Frontend)_](#messaging-client-frontend) or [_`Brainfuck` Execution Visualizer_](#brainfuck-execution-visualizer-frontend)), and complete it.
+Select either one of the React challenges ([_Messaging Client (Frontend)_](#messaging-client-frontend) or [_`Brainf***` Execution Visualizer_](#brainf-execution-visualizer-frontend), and complete it.
 
 Since the React questions will take slightly longer than the others, we only ask that you complete one challenge.
 
@@ -89,15 +89,15 @@ What is the most creative way you can get a circle to appear on the screen of a 
 
 **Read more [here](docs/creative_web.md).**
 
-### `Brainfuck` Interpreter
+### Brainf*** Interpreter
 
-Implement a `Brainfuck` interpreter (as a Ruby class), which takes in a script and executes it.
+Implement a `Brainf***` interpreter (as a Ruby class), which takes in a script and executes it.
 
 **Read more [here](docs/brainfuck_interpreter.md).**
 
-### `Brainfuck` Execution Visualizer (Frontend)
+### Brainf*** Execution Visualizer (Frontend)
 
-You do not need any background context on compilers or the `Brainfuck` language to complete this challenge.
+You do not need any background context on compilers or the `Brainf***` language to complete this challenge.
 
 We want to build an _execution visualizer_, which is a web app that executes a program step by step, and can show at any given time where we are in the program's execution. An example of an execution visualizer can be found [here](https://goo.gl/nDth8B).
 

--- a/docs/brainfuck_execution_visualizer.md
+++ b/docs/brainfuck_execution_visualizer.md
@@ -1,26 +1,26 @@
-# `Brainfuck` Execution Visualizer
+# `Brainf***` Execution Visualizer
 
-> [`Brainfuck`](https://en.wikipedia.org/wiki/Brainfuck) is an esoteric programming language created in 1993 by Urban Müller, and notable for its extreme minimalism.
+> [`Brainf***` (or "BF")](https://en.wikipedia.org/wiki/Brainfuck) is an esoteric programming language created in 1993 by Urban Müller, and notable for its extreme minimalism.
 
-> The language consists of only eight simple commands and an instruction pointer. While it is fully Turing complete, it is not intended for practical use, but to challenge and amuse programmers. Brainfuck simply requires one to break commands into microscopic steps.
+> The language consists of only eight simple commands and an instruction pointer. While it is fully Turing complete, it is not intended for practical use, but to challenge and amuse programmers. BF simply requires one to break commands into microscopic steps.
 
-You do not need any background context on compilers or the `Brainfuck` language to complete this challenge.
+You do not need any background context on compilers or the BF language to complete this challenge.
 
 We want to build an _execution visualizer_, which is a web app that executes a program step by step, and can show at any given time where we are in the program's execution (which line is being run currently), and what our memory currently looks like. An example of an execution visualizer can be found [here](https://goo.gl/nDth8B). We recommend you play with this example for a bit to get familiar with what we are trying to build.
 
-We will provide an API implementing a `Brainfuck` interpreter that will execute a program one step at a time, and return after each step a dump of the current memory.
+We will provide an API implementing a BF interpreter that will execute a program one step at a time, and return after each step a dump of the current memory.
 
-Build a functional, standalone React app that takes in a Brainfuck script (e.g. in a text field), shows the parsed script being executed, intelligently displays the parts of the data array which are not empty (including the string representations of the cell contents, if possible), and indicates where the instruction and data pointers are. There should be a visual indication (animations, colours, etc.) when any of these change.
+Build a functional, standalone React app that takes in a BF script (e.g. in a text field), shows the parsed script being executed, intelligently displays the parts of the data array which are not empty (including the string representations of the cell contents, if possible), and indicates where the instruction and data pointers are. There should be a visual indication (animations, colours, etc.) when any of these change.
 
-This assignment is intentionally open-ended; build whatever you think is appropriate to help someone understand the execution of a Brainfuck script.
+This assignment is intentionally open-ended; build whatever you think is appropriate to help someone understand the execution of a BF script.
 
 To help with this assignment, we provide an API which parses and executes a given script. Initially, you might want to avoid scripts that require input. If you have time, you can add support for providing input via the endpoint below.
 
 #### `POST https://sec.meetkaruna.com/api/v1/brainfuck`
 
-This endpoint takes one mandatory parameter, `script`, which is a string containing the Brainfuck script to be executed. It also takes an optional `input` parameter, which is used to buffer some input characters before execution begins.
+This endpoint takes one mandatory parameter, `script`, which is a string containing the BF script to be executed. It also takes an optional `input` parameter, which is used to buffer some input characters before execution begins.
 
-The response is a representation of the state of a Brainfuck execution environment. This state contains an ID which you need to step through the execution of the script. It also contains an array representing the parsed script, and another showing the data array (this will be quite long).
+The response is a representation of the state of a BF execution environment. This state contains an ID which you need to step through the execution of the script. It also contains an array representing the parsed script, and another showing the data array (this will be quite long).
 
 ```json
 {
@@ -47,4 +47,4 @@ This endpoint takes an optional `input` parameter: a string to be concatenated t
 
 This endpoint also takes an optional `count` parameter: the number of steps to take (defaults to 1).
 
-After processing any additional input, this endpoint steps the Brainfuck interpreter forward by one instruction, and returns the state. Any output thus far can be found in the state, as well as the current values for the instruction and data pointers.
+After processing any additional input, this endpoint steps the BF interpreter forward by one instruction, and returns the state. Any output thus far can be found in the state, as well as the current values for the instruction and data pointers.

--- a/docs/brainfuck_interpreter.md
+++ b/docs/brainfuck_interpreter.md
@@ -1,16 +1,16 @@
-# `Brainfuck` Interpreter
+# `Brainf***` Interpreter
 
-> [`Brainfuck`](https://en.wikipedia.org/wiki/Brainfuck) is an esoteric programming language created in 1993 by Urban Müller, and notable for its extreme minimalism.
+> [`Brainf***` (or BF)](https://en.wikipedia.org/wiki/Brainfuck) is an esoteric programming language created in 1993 by Urban Müller, and notable for its extreme minimalism.
 
-> The language consists of only eight simple commands and an instruction pointer. While it is fully Turing complete, it is not intended for practical use, but to challenge and amuse programmers. Brainfuck simply requires one to break commands into microscopic steps.
+> The language consists of only eight simple commands and an instruction pointer. While it is fully Turing complete, it is not intended for practical use, but to challenge and amuse programmers. BF simply requires one to break commands into microscopic steps.
 
-Implement a `Brainfuck` interpreter (as a Ruby class), which takes in a script and executes it. We will include a single test script to help you test correctness, but encourage you to write more tests.
+Implement a BF interpreter (as a Ruby class), which takes in a script and executes it. We will include a single test script to help you test correctness, but encourage you to write more tests.
 
-The official [Brainfuck language spec](https://www.muppetlabs.com/~breadbox/bf/) and [Wikipedia article](https://en.wikipedia.org/wiki/Brainfuck) will be helpful.
+The official [BF language spec](https://www.muppetlabs.com/~breadbox/bf/) and [Wikipedia article](https://en.wikipedia.org/wiki/Brainfuck) will be helpful.
 
 If you have time, feel free to add creative extensions, such as garbage-collection, or the ability to inspect, debug and step through the execution environment.
 
-The class should be called `Brainfuck`, and it should have a single public method, `interpret!`. The initializer should accept two keyword arguments: `input:` and `output:`, both of type [`IO`](https://ruby-doc.org/core-2.3.1/IO.html). `interpret!` should simply take a `String` containing the instructions of the program to execute.
+The class should be called `Brainfuck` and it should have a single public method, `interpret!`. The initializer should accept two keyword arguments: `input:` and `output:`, both of type [`IO`](https://ruby-doc.org/core-2.3.1/IO.html). `interpret!` should simply take a `String` containing the instructions of the program to execute.
 
 ```ruby
 class BrainfuckTester


### PR DESCRIPTION
### Description

Replaced all instances of the word `brainfuck` with `brainf***` except from filenames, APIs and where we specify the name for the Ruby class.