### PR TITLE
make flow/typescript a requirement for frontend challenges

### DIFF
--- a/docs/brainfuck_execution_visualizer.md
+++ b/docs/brainfuck_execution_visualizer.md
@@ -1,5 +1,7 @@
 # `Brainf***` Execution Visualizer
 
+- Please use type-checking in your submission. We recommend [Flow](https://flow.org) or [Typescript](https://www.typescriptlang.org/).
+
 > [`Brainf***` (or "BF")](https://en.wikipedia.org/wiki/Brainfuck) is an esoteric programming language created in 1993 by Urban Müller, and notable for its extreme minimalism.
 
 > The language consists of only eight simple commands and an instruction pointer. While it is fully Turing complete, it is not intended for practical use, but to challenge and amuse programmers. BF simply requires one to break commands into microscopic steps.

--- a/docs/messaging_client_frontend.md
+++ b/docs/messaging_client_frontend.md
@@ -4,6 +4,7 @@ We wish to build a client for the platform described in the [messaging architect
 
 Build a functional, standalone React app that displays a set of conversations, each with a series of messages between two parties. Assume the person viewing the app is one of the participants in each conversation (don't worry about supporting multiple users). The basic requirements are:
 
+- Please use type-checking in your submission. We recommend [Flow](https://flow.org) or [Typescript](https://www.typescriptlang.org/).
 - Be able to view the list of conversations with others
    - Conversations are displayed in descending order of their last timestamp
    - Display a preview of each conversation (name, unread count, and last message time)


### PR DESCRIPTION
### Description

The requirement was added both to the messaging client and to the brainfuck execution visualizer descriptions so people can't say that they did not see the requirement.